### PR TITLE
update for SONOFF DIY protocol v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ See [http://developers.sonoff.tech/basicr3-rfr3-mini-http-api.html](http://devel
 ## Installing the plugin
 
 1. Ensure your Sonoff Mini is in DIY mode. See [official instructions](http://developers.sonoff.tech/sonoff-diy-mode-api-protocol.html.)
-2. Go to the `domoticz/plugins` directory and clone this repository.
-3. Restart the domoticz service.
+2. Go to the `domoticz/plugins` directory
+3. Clone this repository : git clone [https://github.com/bobzomer/sonoff-domoticz-plugin](https://github.com/bobzomer/sonoff-domoticz-plugin)
+4. Restart the domoticz service.
 
 ## Using the plugin
 Create a new hardware with `Sonoff Mini` type. Specify the IP address of your module. Default port should be OK.
-On the first run the plugin will create a new switch device. Switching this device in Domoticz will
-update your Sonoff Mini. 
+When the device firmware version < 3.5.0, the device ID can be left blank.
+e.g. “Device ID”: “”
+When the device firmware version ≥ 3.5.0, the device ID must be filled in.
+e.g. “Device ID”: “1000000001”
 
-**WARNING:** There will be no reading of status.
+On the first run the plugin will create a new switch device. Switching this device in Domoticz will update your Sonoff Mini. 
 
 ## Issues
 If you find a problem with the plugin, just open an issue here.


### PR DESCRIPTION
Responds to issue #1
Since firmware ≥ 3.5.0, SONOFF DIY protocol (v2.0) needs device ID.
I don’t master Python, the code is surely not very correct, but it works.
Error handling should be added to avoid disrupting Domoticz in case of incorrect parameter entry.

Changes :
Adding device id in the settings
Relay state update